### PR TITLE
Feat : shallowEquals

### DIFF
--- a/src/@lib/equalities/shallowEquals.ts
+++ b/src/@lib/equalities/shallowEquals.ts
@@ -16,12 +16,7 @@ export function shallowEquals<T>(objA: T, objB: T): boolean {
     return true;
   }
 
-  if (
-    typeof objA === "object" &&
-    typeof objB === "object" &&
-    !Array.isArray(objA) &&
-    !Array.isArray(objB)
-  ) {
+  if (typeof objA === "object" && typeof objB === "object") {
     const keysA = Object.keys(objA as object);
     const keysB = Object.keys(objB as object);
 

--- a/src/@lib/equalities/shallowEquals.ts
+++ b/src/@lib/equalities/shallowEquals.ts
@@ -1,3 +1,44 @@
 export function shallowEquals<T>(objA: T, objB: T): boolean {
+  if (objA === null && objB === null) {
+    return objA === objB;
+  }
+
+  if (Array.isArray(objA) && Array.isArray(objB)) {
+    if (objA.length !== objB.length) {
+      return false;
+    }
+
+    for (let index = 0; index < objA.length; index++) {
+      if (objA[index] !== objB[index]) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  if (
+    typeof objA === "object" &&
+    typeof objB === "object" &&
+    !Array.isArray(objA) &&
+    !Array.isArray(objB)
+  ) {
+    const keysA = Object.keys(objA as object);
+    const keysB = Object.keys(objB as object);
+
+    if (keysA.length !== keysB.length) {
+      return false;
+    }
+
+    for (const key of keysA) {
+      if (
+        (objA as Record<string, unknown>)[key] !==
+        (objB as Record<string, unknown>)[key]
+      ) {
+        return false;
+      }
+    }
+    return true;
+  }
+
   return objA === objB;
 }


### PR DESCRIPTION
## 구현 기능 
shallowEquals 

## 학습내용 

1. Record 
`Record<K,T>` 형식으로 사용합니다. 
타입스크립트의 유틸리티 타입 중 하나로, key로 문자열 리터럴을 사용할 수 있습니다.  

```
// 기본적인 사용방법
const userRoles: Record<string, string> = {
  admin: "Admin",
  editor: "Editor",
  viewer: "Viewer",
};

console.log(userRoles.admin); // "Admin"

// 유니온 타입을 키로 지정한 경우 
type Role = "admin" | "editor" | "viewer";

const userPermissions: Record<Role, boolean> = {
  admin: true,
  editor: false,
  viewer: true,
};

console.log(userPermissions.admin); // true
console.log(userPermissions.editor); // false


```

- 정적 키만 정의가 가능합니다. -> 동적으로 키를 생성하는 경우는 사용할 수 없다. 


```
if (
    typeof objA === "object" &&
    typeof objB === "object" 
  ) {
    const keysA = Object.keys(objA as object);
    const keysB = Object.keys(objB as object);

    if (keysA.length !== keysB.length) {
      return false;
    }

    for (const key of keysA) {
      if (
        (objA as Record<string, unknown>)[key] !==
        (objB as Record<string, unknown>)[key]
      ) {
        return false;
      }
    }
    return true;
  }

```
- 밸류를 unknown으로 사용한 이유 
`unknown`은 어떤 값이 올 수 있다는 의미입니다. `any`와 비슷한 역할이지만 그보다 안전한 타입입니다. 
=> 사용하기 전에 타입 검사를 해야만 사용할 수 있기 때문에
테스트케이스에서 숫자형뿐만 아니라 빈 객체도 함께 들어오기 때문에 다양한 타입이 들어올 수 있는 경우를 염두하여 사용했습니다.

