### PR TITLE
Feat : hook 구현하기 

### DIFF
--- a/src/@lib/hooks/useCallback.ts
+++ b/src/@lib/hooks/useCallback.ts
@@ -1,10 +1,10 @@
 /* eslint-disable @typescript-eslint/no-unused-vars,@typescript-eslint/no-unsafe-function-type */
 import { DependencyList } from "react";
+import { useMemo } from "./useMemo";
 
 export function useCallback<T extends Function>(
   factory: T,
-  _deps: DependencyList,
+  _deps: DependencyList
 ) {
-  // 직접 작성한 useMemo를 통해서 만들어보세요.
-  return factory as T;
+  return useMemo(() => factory, _deps);
 }

--- a/src/@lib/hooks/useMemo.ts
+++ b/src/@lib/hooks/useMemo.ts
@@ -1,12 +1,19 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { DependencyList } from "react";
 import { shallowEquals } from "../equalities";
+import { useRef } from "./useRef";
 
 export function useMemo<T>(
   factory: () => T,
   _deps: DependencyList,
-  _equals = shallowEquals,
+  _equals = shallowEquals
 ): T {
-  // 직접 작성한 useRef를 통해서 만들어보세요.
-  return factory();
+  const ref = useRef<{ deps: DependencyList; value: T } | null>(null);
+
+  if (ref.current == null || !_equals(_deps, ref.current.deps)) {
+    ref.current = { deps: _deps, value: factory() };
+    return ref.current.value;
+  }
+
+  return ref.current.value;
 }

--- a/src/@lib/hooks/useRef.ts
+++ b/src/@lib/hooks/useRef.ts
@@ -1,4 +1,6 @@
+import { useState } from "react";
+
 export function useRef<T>(initialValue: T): { current: T } {
-  // React의 useState를 이용해서 만들어보세요.
-  return { current: initialValue };
+  const [ref] = useState(() => ({ current: initialValue }));
+  return ref;
 }


### PR DESCRIPTION
## 구현 내용 
훅 구현하기 

## 학습 내용 
`useRef`, `useCallback`, `useMemo` 

### 1. useRef 
`const ref = useRef(initialValue)` 형태로 사용합니다. 렌더링에 필요하지 않은 값을 참조할 수 있는 리액트 훅입니다. 

초기 값에는 어떤 유형의 값이든 지정할 수 있으며, 인자는 초기 렌더링 이후부터는 무시됩니다. 

**반환값** 
단일 프로퍼티를 가진 객체를 반환합니다. 
- `current` : 처음에는 전달한 초기값으로 설정되며 이후 다른 값으로 바꿀 수 있습니다. jsx 노드의 ref 어트리뷰트로 전달하면 리액트에서 current프로퍼티를 설정합니다. 
  - `<input ref = {ref}/>` 와 같은 형태로 사용합니다. 
- 돔 요소에 접근하거나 이전 상태를 저장하는 등 다양한 용도로 사용될 수 있습니다. 

### 2. useMemo
`const memo = useMemo(calculateValue, dependencies)` 형태로 사용합니다. 재렌더링 사이에 결과를 캐싱할 수 있게 해주는 리액트 훅입니다. 
- `calculateValue` : 캐싱하려는 값을 계산하는 함수. 순수해야하며 인자를 받지않고 모든 타입의 값을 반환할 수 있어야합니다. 초기 렌더링 중에 함수를 호출하며, 마지막 렌더링 이후 `dependencies`가 변경되지 않았을 때 동일한 값을 다시 반환합니다. 
- `dependencies` : `calculateValue`내에서 참조된 모든 반응형 값들의 목록입니다. 반응형 값에는 props, state, component body에 직접 선언된 모든 변수와 함수가 포함됩니다. 

- 값 뿐만 아니라 객체나 배열도 메모이제이션이 가능
- 큰 계산을 최적화할 때 유용합니다. 

**반환값** 
초기 렌더링에서 useMemo는 인자 없이 `calculateValue`를 호출한 결과를 반환합니다. 

**주의** 
- 모든 값에 useMemo를 사용하면 메모리 사용량을 증가시키고 초기 렌더링 성능을 저하시킬 수 있습니다. 
- 잘못된 의존성 배열은 최신 값을 사용하지 못하는 버그를 유발할 수 있습니다. 

### 3. useCallback 
`const callback = useCallback(fn, dependencies)` 
- `fn` : 캐싱할 함수값입니다. 어떤 인자나 반환값도 가질 수 있습니다. 첫 렌더링에서 이 함수를 반환하고, dependencies값이 변경되는 경우에 나중에 재사용할 수 있도록 이를 저장합니다. 
- `dependencies` : fn내에서 참조되는 모든 반응형 값의 목록입니다. 의존성 목록은 항목 수가 일정해야 합니다. 

- useMemo와 함께 사용하여 컴포넌트의 불필요한 리렌더링을 방지합니다 